### PR TITLE
Update css with theme colors and put a link to the app in navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,10 @@ module.exports = {
   organizationName: "mithraiclabs", // Usually your GitHub org/user name.
   projectName: "psyoptions-docs", // Usually your repo name.
   themeConfig: {
+    colorMode: {
+      // "light" | "dark"
+      defaultMode: "dark",
+    },
     navbar: {
       title: "PsyOptions",
       logo: {
@@ -19,6 +23,11 @@ module.exports = {
         {
           to: "https://medium.com/psyoptions",
           label: "Blog",
+          position: "left",
+        },
+        {
+          to: "https://psyoptions.io/",
+          label: "App",
           position: "left",
         },
         {
@@ -69,6 +78,9 @@ module.exports = {
     [
       "@docusaurus/preset-classic",
       {
+        theme: {
+          customCss: [require.resolve("./src/css/custom.css")],
+        },
         docs: {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,0 +1,22 @@
+html[data-theme="light"] {
+  --ifm-color-primary: #dd3e76;
+  --ifm-color-primary-dark: #05044d;
+}
+
+html[data-theme="dark"] {
+  --ifm-menu-color: #aaa;
+  --ifm-hover-overlay: rgba(139, 234, 255, 0.1);
+
+  --ifm-heading-color: #eee;
+
+  --ifm-color-primary: #8beaff;
+  --ifm-color-primary-dark: #5a91ea;
+
+  --ifm-background-surface-color: #2a2a34;
+  --ifm-navbar-background-color: #36343e;
+  --ifm-background-color: #101017;
+}
+
+html[data-theme="dark"] .footer--dark {
+  --ifm-footer-background-color: #36343e;
+}


### PR DESCRIPTION
This updates some of the docusaurus css to match the colors we have in our app / figma theme for both light and dark mode. I also added a link to the app itself in the navbar because we didn't have one before.

![Screen Shot 2021-05-15 at 5 19 07 PM](https://user-images.githubusercontent.com/9023427/118378455-fc2b7280-b5a1-11eb-9752-f09559c9c18f.png)
![Screen Shot 2021-05-15 at 5 19 13 PM](https://user-images.githubusercontent.com/9023427/118378457-fd5c9f80-b5a1-11eb-87b3-c6a792a2521d.png)
